### PR TITLE
126 put deploy using sdks

### DIFF
--- a/source/docs/casper/developers/cli/installing-contracts.md
+++ b/source/docs/casper/developers/cli/installing-contracts.md
@@ -63,7 +63,7 @@ casper-client get-deploy \
 ## Installing a Contract in Global State using different SDKs{#installing-contract-code-sdks}
 Alternatively to installing contracts with the casper-client command line tool, different SDKs can be utilised to send deploys to the JSON-RPC server of a Casper node. Not every SDK is exactly the same, but you can find examples for a selection of different SDKs below.
 
-### 1. Javascript{#installing-contract-code-javascript-sdk}
+## 1. Javascript{#installing-contract-code-javascript-sdk}
 ```javascript
 const fs = require('fs');
 const Get_Binary = function(path){
@@ -146,10 +146,52 @@ const session_args = RuntimeArgs.fromMap({
 });
 ```
 The leftover required arguments for sending a deploy in javascript: `node_address`, `chain_name`, `wasm_path`, `payment_amount` are the same for every SDK and the casper-client command line tool. `payment_amount` sets the installation gas fee and `wasm_path` is a path to the compiled wasm contract that is to be installed.
-### 2. Python{#installing-contract-code-python-sdk}
+## 2. Python{#installing-contract-code-python-sdk}
 In order to install a compiled .wasm smart contract using the Python SDK, we first need to create a keypair and construct an `asymmetric_keypair`.
 See [example](https://github.com/casper-network/casper-python-sdk/blob/main/how_tos/how_to_create_key_pairs.py) on GitHub.
 This is the Pyton equivalent of the `asymmetric_keypair` in the [javascript](#installing-contract-code-javscript-sdk) section.
+Create and sign a deploy with the Python SDK:
+```python
+# Set deploy.
+deploy: Deploy = _get_deploy(args, operator)
+# Approve deploy.
+deploy.approve(operator)
+# Dispatch deploy to a node.
+client.send_deploy(deploy)
+
+
+def _get_deploy(args: argparse.Namespace, operator: PrivateKey) -> Deploy:
+    """Returns delegation deploy to be dispatched to a node.
+    """
+    # Set standard deploy parameters.
+    params: DeployParameters = \
+        pycspr.create_deploy_parameters(
+            account=operator,
+            chain_name=args.chain_name
+            )
+
+    # Set payment logic.
+    payment: ModuleBytes = \
+        pycspr.create_standard_payment(args.deploy_payment)
+
+    # Set session logic.
+    session: ModuleBytes = ModuleBytes(
+        module_bytes=pycspr.read_wasm(args.path_to_wasm),
+        args={
+            "token_decimals": CL_U8(args.token_decimals),
+            "token_name": CL_String(args.token_name),
+            "token_symbol": CL_String(args.token_symbol),
+            "token_total_supply": CL_U256(args.token_total_supply),
+        }
+    )
+
+    return pycspr.create_deploy(params, payment, session)
+
+```
+As you can see, argparse is used in the example to construct `session-arguments`.
+Review the [complete example](https://github.com/casper-network/casper-python-sdk/blob/main/how_tos/how_to_install_a_contract.py) on GitHub to learn more. Additional Python SDK examples can be found [here](https://github.com/casper-network/casper-python-sdk)
+
+
 
 **Video - Contract Installation Walkthrough**
 

--- a/source/docs/casper/developers/cli/installing-contracts.md
+++ b/source/docs/casper/developers/cli/installing-contracts.md
@@ -99,7 +99,7 @@ const Deploy = async function(
 ```
 As you can see, you will need an `asymmetric_keypair` to sign a deploy. See the
 "KeyManager" class below to learn how to create keys locally and
-construct an `asymmetric_keypair` using Ed25519. If you are interested in using Secp256K1 keypairs, you can find more in-depth examples [here](https://github.com/casper-ecosystem/casper-js-sdk/blob/dev/test/lib/Keys.test.ts)
+construct an `asymmetric_keypair` using Ed25519. The code above is only a simple example of how keys can be used to sign deploys. If you are interested in building on Casper, or, for example want to use Secp256K1 keypairs, you can find more in-depth examples [here](https://github.com/casper-ecosystem/casper-js-sdk/blob/dev/test/lib/Keys.test.ts)
 
 ```javascript
 const fs = require('fs');
@@ -145,7 +145,7 @@ const session_args = RuntimeArgs.fromMap({
   // ...
 });
 ```
-The leftover required arguments for sending a deploy in javascript: `node_address`, `chain_name`, `wasm_path`, `payment_amount` are the same for every SDK and the casper-client command line tool. `payment_amount` sets the installation gas fee and `wasm_path` is a path to the compiled wasm contract that is to be installed.
+The left over required arguments for sending a deploy in javascript: `node_address`, `chain_name`, `wasm_path`, `payment_amount` are the same for every SDK and the casper-client command line tool. `payment_amount` sets the installation gas fee and `wasm_path` is a path to the compiled wasm contract that is to be installed.
 ## 2. Python{#installing-contract-code-python-sdk}
 In order to install a compiled .wasm smart contract using the Python SDK, we first need to create a keypair and construct an `asymmetric_keypair`.
 See [example](https://github.com/casper-network/casper-python-sdk/blob/main/how_tos/how_to_create_key_pairs.py) on GitHub.

--- a/source/docs/casper/developers/cli/installing-contracts.md
+++ b/source/docs/casper/developers/cli/installing-contracts.md
@@ -99,7 +99,7 @@ const Deploy = async function(
 ```
 As you can see, you will need an `asymmetric_keypair` to sign a deploy. See the
 "KeyManager" class below to learn how to create keys locally and
-construct an `asymmetric_keypair` using Ed25519.
+construct an `asymmetric_keypair` using Ed25519. If you are interested in using Secp256K1 keypairs, you can find more in-depth examples [here](https://github.com/casper-ecosystem/casper-js-sdk/blob/dev/test/lib/Keys.test.ts)
 
 ```javascript
 const fs = require('fs');

--- a/source/docs/casper/developers/cli/installing-contracts.md
+++ b/source/docs/casper/developers/cli/installing-contracts.md
@@ -60,10 +60,10 @@ casper-client get-deploy \
     --node-address http://localhost:11101 [DEPLOY_HASH]
 ```
 
-## Installing a Contract in Global State using different SDKs
-Alternatively to installing contracts with the casper-client command line tool, different SDKs can send be utilised to send deploys to the JSON-RPC server of a Casper node. Not every SDK works the same, but you can find examples for different SDKs below.
+## Installing a Contract in Global State using different SDKs{#installing-contract-code-sdks}
+Alternatively to installing contracts with the casper-client command line tool, different SDKs can be utilised to send deploys to the JSON-RPC server of a Casper node. Not every SDK is exactly the same, but you can find examples for a selection of different SDKs below.
 
-### 1. Javascript
+### 1. Javascript{#installing-contract-code-javascript-sdk}
 ```javascript
 const fs = require('fs');
 const Get_Binary = function(path){
@@ -145,8 +145,8 @@ const session_args = RuntimeArgs.fromMap({
   // ...
 });
 ```
-
-### 2. Python
+The leftover required arguments for sending a deploy in javascript: `node_address`, `chain_name`, `wasm_path`, `payment_amount` are the same for every SDK and the casper-client command line tool. `payment_amount` sets the installation gas fee and `wasm_path` is a path to the compiled wasm contract that is to be installed.
+### 2. Python{#installing-contract-code-python-sdk}
 
 
 **Video - Contract Installation Walkthrough**

--- a/source/docs/casper/developers/cli/installing-contracts.md
+++ b/source/docs/casper/developers/cli/installing-contracts.md
@@ -147,7 +147,9 @@ const session_args = RuntimeArgs.fromMap({
 ```
 The leftover required arguments for sending a deploy in javascript: `node_address`, `chain_name`, `wasm_path`, `payment_amount` are the same for every SDK and the casper-client command line tool. `payment_amount` sets the installation gas fee and `wasm_path` is a path to the compiled wasm contract that is to be installed.
 ### 2. Python{#installing-contract-code-python-sdk}
-
+In order to install a compiled .wasm smart contract using the Python SDK, we first need to create a keypair and construct an `asymmetric_keypair`.
+See [example](https://github.com/casper-network/casper-python-sdk/blob/main/how_tos/how_to_create_key_pairs.py) on GitHub.
+This is the Pyton equivalent of the `asymmetric_keypair` in the [javascript](#installing-contract-code-javscript-sdk) section.
 
 **Video - Contract Installation Walkthrough**
 


### PR DESCRIPTION
I added a section to installing-contracts where put-deploys are explained. Simple Javascript and Python examples are included, as well as references to the how-tos of the casper-python-sdk and tests in the casper-javascript-sdk. 

The javascript examples is custom and I added a KeyManager class that I wrote when working on a library. I think it's a useful addition to set people up, however I did still link to the official tests, where developers can learn how to use Secp256k1 over Ed25519.