### PR TITLE
Polished counter Example - querying the Network ( NCTL and Testnet )

### DIFF
--- a/source/docs/casper/resources/tutorials/beginner/counter-testnet/commands.md
+++ b/source/docs/casper/resources/tutorials/beginner/counter-testnet/commands.md
@@ -10,7 +10,7 @@ Example:
 ```rust
 casper-client get-state-root-hash --node-address http://[IP]:7777
 ```
-You can find a list of Testnet IP addresses [here](https://testnet.cspr.live/tools/peers)
+You can find a list of Testnet IP addresses at [CSPR live](https://testnet.cspr.live/tools/peers).
 
 The first command to cover is the _get-state-root-hash_ command from the _casper-client_ tool. The state root hash is an identifier of the current network state. It is similar to a Git commit ID for commit history. It gives a snapshot of the blockchain state at a moment in time. For this tutorial, it will be used to query the network state after sending deploys.
 

--- a/source/docs/casper/resources/tutorials/beginner/counter-testnet/commands.md
+++ b/source/docs/casper/resources/tutorials/beginner/counter-testnet/commands.md
@@ -1,10 +1,16 @@
-# Important Commands
+# Casper-Client Commands
 
 ## State Root Hash {#state-root-hash}
 
 ```rust
 casper-client get-state-root-hash --node-address [NODE_SERVER_ADDRESS]
 ```
+
+Example:
+```rust
+casper-client get-state-root-hash --node-address http://[IP]:7777
+```
+You can find a list of Testnet IP addresses [here](https://testnet.cspr.live/tools/peers)
 
 The first command to cover is the _get-state-root-hash_ command from the _casper-client_ tool. The state root hash is an identifier of the current network state. It is similar to a Git commit ID for commit history. It gives a snapshot of the blockchain state at a moment in time. For this tutorial, it will be used to query the network state after sending deploys.
 

--- a/source/docs/casper/resources/tutorials/beginner/counter-testnet/index.md
+++ b/source/docs/casper/resources/tutorials/beginner/counter-testnet/index.md
@@ -10,7 +10,7 @@ This tutorial installs a simple counter contract on the Casper Testnet. The cont
 Here is how the tutorial is structured:
 
 - [Tutorial Overview](./overview.md) - Introduction to the process and what will be covered
-- [Important Commands](./commands.md) - A summary of all relevant commands and respective arguments
+- [Casper-Client Commands](./commands.md) - A summary of all relevant commands and respective arguments
 - [Tutorial Walkthrough](./walkthrough.md) - Step-by-step tutorial instructions 
 
 ## Prerequisites {#prerequisites}

--- a/source/docs/casper/resources/tutorials/beginner/counter/commands.md
+++ b/source/docs/casper/resources/tutorials/beginner/counter/commands.md
@@ -1,4 +1,4 @@
-# Important Commands
+# Casper-Client Commands
 
 ## Faucet Account Information {#faucet-account-information}
 
@@ -34,7 +34,12 @@ casper-client query-global-state \
 
 This command allows you to query the state of a Casper network at a given moment in time, which is specified by the _state-root-hash_ described above.
 
--   The _node-address_ is the server (localhost when running on a local NCTL network).
+-   The _node-address_ is the server's _IP:PORT_, where port is usually the default RPC-port when setting up an NCTL network is _11101_ (IP == localhost when running on a local NCTL network).
+
+Example:
+```rust
+  casper-client ... --node-address http://localhost:11101
+```
 -   The _key_ is the identifier for the query. It must be either the account public key, account hash, contract address hash, transfer hash, or deploy hash. The tutorial demonstrates two of these key types.
 -   The optional query path argument (_q_) allows you to drill into the specifics of a query concerning the key.
 

--- a/source/docs/casper/resources/tutorials/beginner/counter/commands.md
+++ b/source/docs/casper/resources/tutorials/beginner/counter/commands.md
@@ -34,12 +34,7 @@ casper-client query-global-state \
 
 This command allows you to query the state of a Casper network at a given moment in time, which is specified by the _state-root-hash_ described above.
 
--   The _node-address_ is the server's _IP:PORT_, where port is usually the default RPC-port when setting up an NCTL network is _11101_ (IP == localhost when running on a local NCTL network).
-
-Example:
-```rust
-  casper-client ... --node-address http://localhost:11101
-```
+-   The _node-address_ is the location of the RPC endpoint, which is typically represented in the form `http://IP:PORT`. In this particular tutorial, for a default-configured NCTL network running locally, the address you can use is `http://localhost:11101`.
 -   The _key_ is the identifier for the query. It must be either the account public key, account hash, contract address hash, transfer hash, or deploy hash. The tutorial demonstrates two of these key types.
 -   The optional query path argument (_q_) allows you to drill into the specifics of a query concerning the key.
 

--- a/source/docs/casper/resources/tutorials/beginner/counter/index.md
+++ b/source/docs/casper/resources/tutorials/beginner/counter/index.md
@@ -10,7 +10,7 @@ This tutorial installs a simple counter contract on a local Casper network with 
 Here is how the tutorial is structured:
 
 - [Tutorial Overview](./overview.md) - Introduction to the process and what will be covered
-- [Important Commands](./commands.md) - A summary of all relevant commands and respective arguments
+- [Casper-Client Commands](./commands.md) - A summary of all relevant commands and respective arguments
 - [Tutorial Walkthrough](./walkthrough.md) - Step-by-step tutorial instructions 
 
 ## Prerequisites {#prerequisites}


### PR DESCRIPTION
Polished "querying the Network" in counter example ( NCTL and Testnet ). Added an example for the default configuration ( http://localhost:11101 and a link to peers on testnet.cspr.live to make the --node-address more clear.
