### PR TITLE
add rust-nightly instructions

### DIFF
--- a/source/docs/casper/developers/writing-onchain-code/getting-started.md
+++ b/source/docs/casper/developers/writing-onchain-code/getting-started.md
@@ -4,7 +4,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This guide covers the basic tools you will need to set up your first Casper smart contract. You will also be able to build a sample smart contract and run a few basic tests on it on your local machine.
 
-Casper's blockchain is built upon the Rust programming language and compiles down to WebAssembly. This guide will walk you through the steps to set up your development environment and build your first contract. 
+Casper's blockchain is built upon the Rust programming language and compiles down to WebAssembly. This guide will walk you through the steps to set up your development environment and build your first contract.
 
 ## Prerequisites {#prerequisites}
 
@@ -25,6 +25,19 @@ Once you finish installing Rust, check your version:
 ```bash
 rustup --version
 ```
+**Rust-nightly**
+You will need the latest nightly toolchain to develop smart contracts in Rust. Please refer to the [Rust Documentation on Channels](https://rust-lang.github.io/rustup/concepts/channels.html) and the [Rust Documentation on Toolchains](https://rust-lang.github.io/rustup/concepts/toolchains.html) for further information.
+
+**Rust-nightly quickstart**
+```bash
+$ rustup toolchain install nightly
+$ rustup default nightly
+```
+To check your current version of rust-nightly:
+```bash
+$ rustup run nightly rustc --version
+```
+
 
 **Casper Rust Packages**
 
@@ -135,7 +148,7 @@ As a brief example, open up _my-project/contract/src/main.rs_ in your editor, mo
 
 ### Installing the Casper Client
 
-We also provide a [Casper command-line client](../prerequisites.md#the-casper-command-line-client), a Rust CLI tool that can help you transmit deploys and install code on-chain. 
+We also provide a [Casper command-line client](../prerequisites.md#the-casper-command-line-client), a Rust CLI tool that can help you transmit deploys and install code on-chain.
 
 ### Setting up an IDE
 


### PR DESCRIPTION
Added instructions to setup rust-nightly to the "getting-started" section for installing, writing on-chain code.
