### PR TITLE
add missing tab import

### DIFF
--- a/source/docs/casper/developers/dapps/technology-stack.md
+++ b/source/docs/casper/developers/dapps/technology-stack.md
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # dApp Technology Stack
 
 There are 3 layers to building a decentralized application that interacts with the Casper Network: Front-end, backend, and blockchain. This document outlines lists the requirements for each.


### PR DESCRIPTION
### What does this PR fix/introduce?
Added missing imports for tabs 

### Additional context
Imports were missing in dApp Technology stack tutorial

### Checklist

- [x ] I ran the docs locally using `yarn install` and `yarn run start`.
- [x ] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
- [x ] All links (internal and external) have been verified.
- [x ] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).
- [ x] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@andrzej-casper 