### PR TITLE
add content to index.md - Operators

### DIFF
--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -12,7 +12,7 @@ Prior knowledge of Unix-based operating systems and proficiency with systemd and
 # Requirements
 1. Operators should be aware of the [Hardware requirements](./setup/hardware.md) before considering to run a node.
 
-2. Also, make sure you are aware of the [Network requirements](./setup/install-node.md#network-requirements) as you will have to open ports / modify the firewall of the network the node is connected to. This is necessary to allow incoming connections, enabling communication between nodes.
+2. Also, make sure you are aware of the [Network requirements](./setup/install-node.md/#network-requirements) as you will have to open ports / modify the firewall of the network the node is connected to. This is necessary to allow incoming connections, enabling communication between nodes.
 
 # Content overview
 If you are familiar with the Casper node and want to quickly setup a new instance, you may skip to the [Installation instructions](./setup/install-node.md). Otherwise, it's recommended to review the [Configuration instructions](./setup/basic-node-configuration.md) first.

--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -8,3 +8,13 @@ slug: /operators
 Operators who wish to run node infrastructure on a Casper network, either as a standalone private network, or as part of the public network should explore this section.
 
 Prior knowledge of Unix-based operating systems and proficiency with systemd and bash scripting are recommended. If you are unfamiliar with systemd, the [Arch Linux page on systemd](https://wiki.archlinux.org/title/systemd) is a good introduction.
+
+# Requirements
+1. Operators should be aware of the [Hardware requirements](./setup/hardware.md) before considering to run a node.
+
+2. Also, make sure you are aware of the [Network requirements](./setup/install-node.md#network-requirements) as you will have to open ports / modify the firewall of the network the node is connected to. This is necessary to allow incoming connections, enabling communication between nodes.
+
+# Content overview
+If you are familiar with the Casper node and want to quickly setup a new instance, you may skip to the [Installation instructions](./setup/install-node.md). Otherwise, it's recommended to review the [Configuration instructions](./setup/basic-node-configuration.md) first.
+
+To research a specific feature of the node, setup a private network, or become a validator, review the [Table of Contents](./table-of-contents.md) for Operators.

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -1,8 +1,8 @@
-# Installing a Node 
+# Installing a Node
 
 Ensure the requirements listed in the following sections are met before you start setting up the node on the network, either on Mainnet or Testnet.
 
-## Network Requirements
+## Network Requirements {#network-requirements}
 
 The following ports are used by the node:
 
@@ -134,6 +134,3 @@ The community has created a few tools to monitor your node once it is running, s
 
 - Status.py: https://github.com/RapidMark/casper-tools
 - Grafana: https://github.com/matsuro-hadouken/casper-tools
-
-
-


### PR DESCRIPTION
Added content and more clear directions to the Operators index page. I didn't want to remove the "table of contents", which is why integrated it in the text. Thought of a scenario where an experienced Operator wants to quickly setup another instance without having to skip through pages, whilst directing unexperienced Operators to the Configuration guide and those who are in search of a specific feature or action to the table of contents ( that may be a distraction in scenario 1 or 2 ).

