### PR TITLE
new table of contents for Resources

### DIFF
--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -1,13 +1,13 @@
 # Table of Contents
 
 Introduction
-  - [Wallets and Block Explorers](./build-on-casper/introduction/#wallets)
+  - [Wallets and Block Explorers](./build-on-casper/introduction.md#wallets)
   See a list of Wallets that support the native Casper token $CSPR
-  - [WebAssembly](./build-on-casper/introduction/#developer-friendly-language)
+  - [WebAssembly](./build-on-casper/introduction.md#developer-friendly-language)
   Learn why WebAssembly is an advantage in contract development
-  - [Accounts](./build-on-casper/introduction/#powerful-accounts)
+  - [Accounts](./build-on-casper/introduction.md#powerful-accounts)
   Read more about the Casper account-model that allows for features like multisig
-  - [Developer tools](./build-on-casper/introduction/#development-tools)
+  - [Developer tools](./build-on-casper/introduction.md#development-tools)
   Explore development tools
 
 Tutorials

--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -1,13 +1,13 @@
 # Table of Contents
 
 Introduction
-  - [Wallets and Block Explorers](./build-on-casper/introduction.md#wallets)
+  - [Wallets and Block Explorers](./build-on-casper/index.md#wallets)
   See a list of Wallets that support the native Casper token $CSPR
-  - [WebAssembly](./build-on-casper/introduction.md#developer-friendly-language)
+  - [WebAssembly](./build-on-casper/index.md#developer-friendly-language)
   Learn why WebAssembly is an advantage in contract development
-  - [Accounts](./build-on-casper/introduction.md#powerful-accounts)
+  - [Accounts](./build-on-casper/index.md#powerful-accounts)
   Read more about the Casper account-model that allows for features like multisig
-  - [Developer tools](./build-on-casper/introduction.md#development-tools)
+  - [Developer tools](./build-on-casper/index.md#development-tools)
   Explore development tools
 
 Tutorials

--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -2,13 +2,19 @@
 
 - Introduction
   - [Wallets and Block Explorers](./build-on-casper/introduction/#wallets)
+  See a list of Wallets that support the native Casper token $CSPR
   - [WebAssembly](./build-on-casper/introduction/#developer-friendly-language)
+  Learn why WebAssembly is an advantage in contract development
   - [Accounts](./build-on-casper/introduction/#powerful-accounts)
-  - [Developer tools](./build-on-casper/introduction/#development-tools)
+  Read more about the Casper account-model that allows for features like multisig
+  - other [Developer tools](./build-on-casper/introduction/#development-tools)
 
 - Tutorials
   - [Beginner](./tutorials/beginner/index.md)
+  Learn to perform basic actions on the Casper Blockchain, such as read / write operations and SDK queries
   - [Advanced](./tutorials/advanced/index.md)
-
+  Perform more advanced actions, such as multisig, exchange integration and vaults
 - [Quickstart](./quick-start.md)
+  Install Rust and setup a Casper environment 
 - [Open-Source Ecosystem](./build-on-casper/casper-open-source-software.md)
+  Explore the source code that makes up the Casper ecosystem.

--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -7,7 +7,8 @@ Introduction
   Learn why WebAssembly is an advantage in contract development
   - [Accounts](./build-on-casper/introduction/#powerful-accounts)
   Read more about the Casper account-model that allows for features like multisig
-  - other [Developer tools](./build-on-casper/introduction/#development-tools)
+  - [Developer tools](./build-on-casper/introduction/#development-tools)
+  Explore development tools
 
 Tutorials
   - [Beginner](./tutorials/beginner/index.md)

--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -1,8 +1,14 @@
 # Table of Contents
 
-- [Why Build On Casper](./build-on-casper/index.md)
-  - [Ecosystem Open-Source Software](./build-on-casper/casper-open-source-software.md)
+- Introduction
+  - [Wallets and Block Explorers](./build-on-casper/introduction/#wallets)
+  - [WebAssembly](./build-on-casper/introduction/#developer-friendly-language)
+  - [Accounts](./build-on-casper/introduction/#powerful-accounts)
+  - [Developer tools](./build-on-casper/introduction/#development-tools)
+
+- Tutorials
+  - [Beginner](./tutorials/beginner/index.md)
+  - [Advanced](./tutorials/advanced/index.md)
+
 - [Quickstart](./quick-start.md)
-- [Tutorials](./tutorials/index.md)
-  - [Beginner Tutorials](./tutorials/beginner/index.md)
-  - [Advanced Tutorials](./tutorials/advanced/index.md)
+- [Open-Source Ecosystem](./build-on-casper/casper-open-source-software.md)

--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -1,6 +1,6 @@
 # Table of Contents
 
-- Introduction
+Introduction
   - [Wallets and Block Explorers](./build-on-casper/introduction/#wallets)
   See a list of Wallets that support the native Casper token $CSPR
   - [WebAssembly](./build-on-casper/introduction/#developer-friendly-language)
@@ -9,12 +9,12 @@
   Read more about the Casper account-model that allows for features like multisig
   - other [Developer tools](./build-on-casper/introduction/#development-tools)
 
-- Tutorials
+Tutorials
   - [Beginner](./tutorials/beginner/index.md)
   Learn to perform basic actions on the Casper Blockchain, such as read / write operations and SDK queries
   - [Advanced](./tutorials/advanced/index.md)
   Perform more advanced actions, such as multisig, exchange integration and vaults
-- [Quickstart](./quick-start.md)
+  - [Quickstart](./quick-start.md)
   Install Rust and setup a Casper environment 
-- [Open-Source Ecosystem](./build-on-casper/casper-open-source-software.md)
+  - [Open-Source Ecosystem](./build-on-casper/casper-open-source-software.md)
   Explore the source code that makes up the Casper ecosystem.


### PR DESCRIPTION
### What does this PR fix/introduce?
Add content to Resources table of contents page.


- [ x] Docs are successfully building - `yarn install && yarn run build`.
- [ x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [ x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
