### PR TITLE
199 unified sdk calling contracts

### DIFF
--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -271,3 +271,6 @@ print(deploy.hash.hex())
 </Tabs>
 
 Once submitted, the above snippet will print the deploy hash in the console.
+
+## Calling Contracts
+

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -222,7 +222,7 @@ const contract = new Contracts.Contract(client)
 const contractWasm = new Uint8Array(fs.readFileSync("/path/to/contract.wasm").buffer)
 
 const runtimeArguments = RuntimeArgs.fromMap({
-  "argument": CLValueBuilder.string("Hello world!")
+  "message": CLValueBuilder.string("Hello world!")
 })
 
 const deploy = contract.install(
@@ -274,3 +274,69 @@ Once submitted, the above snippet will print the deploy hash in the console.
 
 ## Calling Contracts
 
+Smart contracts on the Casper Network are invoked by calling entrypoints. See below how to use Casper's SDKs to interact with these entrypoints and update the global state from a dApp:
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+```javascript
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc");
+const contract = new Contracts.Contract(casperClient);
+contract.setContractHash(
+	"hash-a3cac24aec9de1bbdb87083587b14d8aeffba5dfed27686512b7bb5dee60445d"
+);
+const runtimeArguments = RuntimeArgs.fromMap({
+  "message": CLValueBuilder.string("Hello world!")
+})
+
+const deploy = contract.callEntrypoint(
+  "update_msg",
+  runtimeArguments,
+  keypair.publicKey,
+  "casper", // or "casper-test" for Testnet
+  "1000000000", // 1 CSPR (10^9 Motes)
+  [keypair]
+);
+
+(async () => {
+  console.log(await casperClient.putDeploy(deploy))
+})();
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+import pycspr
+
+client = NodeClient(NodeConnection(host = "NODE_ADDRESS", port_rpc = 7777))
+
+deployParams = pycspr.create_deploy_parameters(
+    account = keypair,
+    chain_name = "casper-test"
+)
+
+payment = pycspr.create_standard_payment(10_000_000_000)
+
+session = pycspr.types.StoredContractByHash(
+    entry_point = "update_msg",
+    hash = bytes.fromhex("a3cac24aec9de1bbdb87083587b14d8aeffba5dfed27686512b7bb5dee60445d"),
+    args = {
+        "message": pycspr.types.CL_String("Hello world!"),
+    }
+)
+
+deploy = pycspr.create_deploy(deployParams, payment, session)
+
+deploy.approve(keypair)
+client.send_deploy(deploy)
+print(deploy.hash.hex())
+```
+
+</TabItem>
+
+</Tabs>
+
+Once submitted, the above snippet will print the deploy hash in the console.


### PR DESCRIPTION
### What does this PR fix/introduce?
Added Calling Contracts to Unified SDK Document

Closes #199 
### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@KMCreatesWorlds 
