### PR TITLE
178 check if rust can be added to sdks

### DIFF
--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -380,9 +380,9 @@ async fn put_deploy(){
         session_account: "01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a"
 
     };
-    // without session args:
-    //let session_args: Vec<&str> = Vec::new();
-    // with session args:
+    // Without session args:
+    // let session_args: Vec<&str> = Vec::new();
+    // With session args:
     let mut session_args: Vec<&str> = Vec::new();
     session_args.push("argument:String='hello world'");
     let session_params: casper_client::SessionStrParams = casper_client::SessionStrParams::with_path("./contract.wasm", session_args, "");

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -30,6 +30,38 @@ pip install pycspr
 
 </TabItem>
 
+<TabItem value="rust" label="Rust">
+
+Include the casper-client dependency to your `Cargo.toml`:
+
+```
+[dependencies]
+casper-client="1.5.1"
+```
+
+and add it to your `main.rs`:
+
+```rust
+extern crate casper_client;
+```
+
+use types and methods from casper_client:
+
+```rust
+use casper_client::transfer;
+use casper_client::put_deploy;
+//...
+```
+
+as casper_client functions are asynchronous, a tokyo runtime is necessary for testing:
+
+```
+[dependencies]
+tokio = { version = "^1.27.0", features = ["full"] }
+```
+
+</TabItem>
+
 </Tabs>
 
 ---
@@ -59,6 +91,17 @@ Replace `Ed25519` with `Secp256K1` if you wish.
 ```python
 from pycspr.crypto import KeyAlgorithm, get_key_pair
 keypair = get_key_pair(KeyAlgorithm.ED25519)
+```
+
+Replace `ED25519` with `SECP256K1` if you wish.
+
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+
+Create a keypair and write the files to a specified `PATH`:
+```rust
+    casper_client::keygen::generate_files("PATH", "ED25519", false).unwrap();
 ```
 
 Replace `ED25519` with `SECP256K1` if you wish.
@@ -131,6 +174,20 @@ Replace `ED25519` with `SECP256K1` if you wish.
 
 </TabItem>
 
+<TabItem value="rust" label="Rust">
+
+In Rust, we don't explicitly import the private key as an object, but instead supply its path as an argument when calling functions:
+
+```rust
+let deploy_params: casper_client::DeployStrParams = casper_client::DeployStrParams{
+    secret_key:"./secret_key.pem",
+    timestamp:"",
+    ...
+};
+```
+
+</TabItem>
+
 </Tabs>
 
 ---
@@ -194,6 +251,41 @@ deploy = pycspr.create_transfer(
 deploy.approve(keypair)
 client.send_deploy(deploy)
 print(deploy.hash.hex())
+```
+
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+
+```rust
+extern crate casper_client;
+async fn send_transfer(){
+    let maybe_rpc_id: &str = "";
+    let node_address: &str = "http://135.181.216.142:7777";
+    let verbosity_level: u64 = 1;
+    let amount: &str = "2500000000";
+    let target_account: &str = recipient;
+    let transfer_id: &str = "1";
+    let deploy_params: casper_client::DeployStrParams = casper_client::DeployStrParams{
+        secret_key:"./sk_testnet.pem",
+        timestamp:"",
+        ttl:"50s",
+        gas_price:"1000000000",
+        chain_name:"casper", // or "casper-test" for testnet
+        dependencies: Vec::new(),
+        session_account: "01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a"
+
+    };
+    let recipient: &str = "0106ca7c39cd272dbf21a86eeb3b36b7c26e2e9b94af64292419f7862936bca2ca";
+    let payment_params: casper_client::PaymentStrParams = casper_client::PaymentStrParams::with_amount(amount);
+    let result = casper_client::transfer(maybe_rpc_id, node_address, verbosity_level, amount, target_account, transfer_id, deploy_params, payment_params).await.unwrap();
+    println!("Deploy response: {:?}", result);
+}
+
+#[tokio::main]
+async fn main(){
+    send_transfer().await;
+}
 ```
 
 </TabItem>
@@ -266,6 +358,43 @@ deploy = pycspr.create_deploy(deployParams, payment, session)
 deploy.approve(keypair)
 client.send_deploy(deploy)
 print(deploy.hash.hex())
+```
+
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+
+```rust
+extern crate casper_client;
+async fn put_deploy(){
+    let maybe_rpc: &str = "";
+    let verbosity: u64 = 1;
+    let node_address: &str = "http://135.181.216.142:7777";
+    let deploy_params: casper_client::DeployStrParams = casper_client::DeployStrParams{
+        secret_key:"./sk_testnet.pem",
+        timestamp:"",
+        ttl:"50s",
+        gas_price:"1000000000",
+        chain_name:"casper", // or "casper-test"
+        dependencies: Vec::new(),
+        session_account: "01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a"
+
+    };
+    // without session args:
+    //let session_args: Vec<&str> = Vec::new();
+    // with session args:
+    let mut session_args: Vec<&str> = Vec::new();
+    session_args.push("argument:String='hello world'");
+    let session_params: casper_client::SessionStrParams = casper_client::SessionStrParams::with_path("./contract.wasm", session_args, "");
+    let payment_params: casper_client::PaymentStrParams = casper_client::PaymentStrParams::with_amount("10000000000");
+    let result = casper_client::put_deploy(maybe_rpc_id, node_address, verbosity_level, deploy_params, session_params, payment_params).await.unwrap();
+    println!("Deploy response: {:?}", result);
+}
+
+#[tokio::main]
+async fn main(){
+    send_transfer().await;
+}
 ```
 
 </TabItem>
@@ -360,6 +489,43 @@ deploy = pycspr.create_validator_delegation(
 deploy.approve(keypair)
 client.send_deploy(deploy)
 print(deploy.hash.hex())
+```
+
+</TabItem>
+
+<TabItem value="rust" label="Rust">
+
+```rust
+extern crate casper_client;
+async fn put_deploy(){
+    let maybe_rpc: &str = "";
+    let verbosity: u64 = 1;
+    let node_address: &str = "http://135.181.216.142:7777";
+    let deploy_params: casper_client::DeployStrParams = casper_client::DeployStrParams{
+        secret_key:"./sk_testnet.pem",
+        timestamp:"",
+        ttl:"50s",
+        gas_price:"1000000000",
+        chain_name:"casper", // or "casper-test" for testnet
+        dependencies: Vec::new(),
+        session_account: "01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a"
+
+    };
+    let mut session_args: Vec<&str> = Vec::new();
+    session_args.push("amount:U512='500000000000'");
+    session_args.push("delegator:key='01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a'");
+    session_args.push("validator:key='validator_public_key'");
+    // test with session args -> tbd
+    let session_params: casper_client::SessionStrParams = casper_client::SessionStrParams::with_path("./delegate.wasm", session_args, "");
+    let payment_params: casper_client::PaymentStrParams = casper_client::PaymentStrParams::with_amount("5000000000");
+    let result = casper_client::put_deploy(maybe_rpc, node_address, verbosity, deploy_params, session_params, payment_params).await.unwrap();
+    println!("Deploy result: {:?}", result);
+}
+
+#[tokio::main]
+async fn main(){
+    put_deploy().await;
+}
 ```
 
 </TabItem>

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -516,7 +516,7 @@ async fn put_deploy(){
     
     session_args.push("delegator:public_key='01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a'");
     session_args.push("validator:public_key='validator_public_key'");
-    // test with session args -> tbd
+  
     let session_params: casper_client::SessionStrParams = casper_client::SessionStrParams::with_path("./delegate.wasm", session_args, "");
     let payment_params: casper_client::PaymentStrParams = casper_client::PaymentStrParams::with_amount("5000000000");
     let result = casper_client::put_deploy(maybe_rpc, node_address, verbosity, deploy_params, session_params, payment_params).await.unwrap();

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -513,8 +513,8 @@ async fn put_deploy(){
     };
     let mut session_args: Vec<&str> = Vec::new();
     session_args.push("amount:U512='500000000000'");
-    session_args.push("delegator:key='01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a'");
-    session_args.push("validator:key='validator_public_key'");
+    session_args.push("delegator:Key='01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a'");
+    session_args.push("validator:Key='validator_public_key'");
     // test with session args -> tbd
     let session_params: casper_client::SessionStrParams = casper_client::SessionStrParams::with_path("./delegate.wasm", session_args, "");
     let payment_params: casper_client::PaymentStrParams = casper_client::PaymentStrParams::with_amount("5000000000");

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -513,8 +513,9 @@ async fn put_deploy(){
     };
     let mut session_args: Vec<&str> = Vec::new();
     session_args.push("amount:U512='500000000000'");
-    session_args.push("delegator:Key='01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a'");
-    session_args.push("validator:Key='validator_public_key'");
+    
+    session_args.push("delegator:public_key='01daad67ebbcb725e02a1955a6617512b311435a21ca6d523085aa015d2d1b473a'");
+    session_args.push("validator:public_key='validator_public_key'");
     // test with session args -> tbd
     let session_params: casper_client::SessionStrParams = casper_client::SessionStrParams::with_path("./delegate.wasm", session_args, "");
     let payment_params: casper_client::PaymentStrParams = casper_client::PaymentStrParams::with_amount("5000000000");

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -45,7 +45,7 @@ and add it to your `main.rs`:
 extern crate casper_client;
 ```
 
-use types and methods from casper_client:
+Use types and methods from casper_client:
 
 ```rust
 use casper_client::transfer;


### PR DESCRIPTION
I added Rust examples utilising the casper-client crate alongside the Javascript and Python SDK examples. I tried to keep it simple and follow a similar structure. I tested all functions and everything looks good on my end. 
